### PR TITLE
OPUS improvements

### DIFF
--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/CsvMember.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/CsvMember.cs
@@ -82,6 +82,15 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 
         public ICollection<DynamicObjectProperty> DynamicProperties { get; set; }
 
+        public bool IdsEquals(Member member) =>
+            (!string.IsNullOrEmpty(Id) && Id.EqualsInvariant(member.Id))
+            || (!string.IsNullOrEmpty(OuterId) && OuterId.EqualsInvariant(member.OuterId));
+
+        public static bool IdsEquals(string id, string outerId, Member member) =>
+            (!string.IsNullOrEmpty(id) && id.EqualsInvariant(member.Id))
+            || (!string.IsNullOrEmpty(outerId) && outerId.EqualsInvariant(member.OuterId));
+
+
         protected void PatchDynamicProperties(Member target)
         {
             target.DynamicProperties ??= new List<DynamicObjectProperty>();
@@ -134,6 +143,5 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
                 target.Addresses.Add(address);
             }
         }
-
     }
 }

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/CsvMember.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/CsvMember.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using CsvHelper.Configuration.Attributes;
+using Newtonsoft.Json;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
@@ -69,7 +70,13 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
         [Name("Address Phone")]
         public virtual string AddressPhone { get; set; }
 
-        [Ignore]
+        [Optional]
+        [Name("Additional Line")]
+        [BooleanTrueValues("True", "Yes")]
+        [BooleanFalseValues("False", "No")]
+        public virtual bool? AdditionalLine { get; set; }
+
+        [Ignore, JsonIgnore]
         public string ObjectType { get; set; }
 
         public ICollection<DynamicObjectProperty> DynamicProperties { get; set; }

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ExportDataRequest.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ExportDataRequest.cs
@@ -14,13 +14,14 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 
         public MembersSearchCriteria ToSearchCriteria()
         {
-            return new MembersSearchCriteria
+            return new ExtendedMembersSearchCriteria
             {
-                Keyword = ObjectIds.IsNullOrEmpty() ? Keyword : null,//if concrete members selected there is no index searching
+                Keyword = ObjectIds.IsNullOrEmpty() ? Keyword : null, // if concrete members selected there is no index searching
                 ObjectIds = ObjectIds,
                 MemberId = OrganizationId,
                 MemberTypes = new[] { nameof(Contact), nameof(Organization) },
-                DeepSearch = true
+                DeepSearch = true,
+                ExportData = true
             };
         }
     }

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ExtendedMembersSearchCriteria.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ExtendedMembersSearchCriteria.cs
@@ -4,7 +4,6 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 {
     public class ExtendedMembersSearchCriteria : MembersSearchCriteria
     {
-        public string[] OuterIds { get; set; }
         public bool? ExportData { get; set; }
     }
 }

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ExtendedMembersSearchCriteria.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ExtendedMembersSearchCriteria.cs
@@ -5,5 +5,6 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
     public class ExtendedMembersSearchCriteria : MembersSearchCriteria
     {
         public string[] OuterIds { get; set; }
+        public bool? ExportData { get; set; }
     }
 }

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/IExportable.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/IExportable.cs
@@ -1,7 +1,7 @@
 namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 {
     /// <summary>
-    /// Interface to implement exportаble entities.
+    /// Interface to implement exportable entities.
     /// </summary>
     public interface IExportable
     {

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/IImportable.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/IImportable.cs
@@ -1,0 +1,12 @@
+namespace VirtoCommerce.CustomerExportImportModule.Core.Models
+{
+    /// <summary>
+    /// Interface to implement importable entities.
+    /// </summary>
+    public interface IImportable
+    {
+        string RecordName { get; set; }
+
+        bool? AdditionalLine { get; set; }
+    }
+}

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportProgressInfo.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportProgressInfo.cs
@@ -18,6 +18,8 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 
         public int CreatedCount { get; set; }
 
+        public int AdditionalLineCount { get; set; }
+
         public int UpdatedCount { get; set; }
 
         public int ErrorCount { get; set; }

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportableContact.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportableContact.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
-using Address = VirtoCommerce.CustomerModule.Core.Model.Address;
 
 namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 {
@@ -54,10 +53,9 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 
                 PatchDynamicProperties(target);
 
-                target.SecurityAccounts = new List<ApplicationUser>();
-                var accountSpecified = new[] { AccountLogin, AccountEmail }.Any(accountField => !string.IsNullOrEmpty(accountField));
-
-                if (accountSpecified)
+                target.SecurityAccounts ??= new List<ApplicationUser>();
+                if ((!string.IsNullOrEmpty(AccountLogin) || !string.IsNullOrEmpty(AccountEmail))
+                    && !target.SecurityAccounts.Any(x => x.UserName.EqualsInvariant(AccountLogin) && x.Email.EqualsInvariant(AccountEmail)))
                 {
                     target.SecurityAccounts.Add(
                         new ApplicationUser
@@ -75,27 +73,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
                 }
             }
 
-            target.Addresses ??= new List<Address>();
-            var isAddressSpecified = new[] { AddressCountry, AddressCountryCode, AddressRegion, AddressCity, AddressLine1, AddressLine2, AddressZipCode }.Any(addressField => !string.IsNullOrEmpty(addressField));
-
-            if (isAddressSpecified)
-            {
-                target.Addresses.Add(new Address
-                {
-                    AddressType = EnumUtility.SafeParse(AddressType, CoreModule.Core.Common.AddressType.BillingAndShipping),
-                    FirstName = AddressFirstName,
-                    LastName = AddressLastName,
-                    CountryName = AddressCountry,
-                    CountryCode = AddressCountryCode,
-                    RegionName = AddressRegion,
-                    City = AddressCity,
-                    Line1 = AddressLine1,
-                    Line2 = AddressLine2,
-                    PostalCode = AddressZipCode,
-                    Email = AddressEmail,
-                    Phone = AddressPhone,
-                });
-            }
+            PatchAddresses(target);
         }
 
         public Organization ToOrganization()

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportableOrganization.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportableOrganization.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using CsvHelper.Configuration.Attributes;
 using Newtonsoft.Json;
-using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.CustomerModule.Core.Model;
-using Address = VirtoCommerce.CustomerModule.Core.Model.Address;
 
 namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 {
@@ -59,27 +55,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
                 PatchDynamicProperties(target);
             }
 
-            target.Addresses ??= new List<Address>();
-            var isAddressSpecified = new[] { AddressCountry, AddressCountryCode, AddressRegion, AddressCity, AddressLine1, AddressLine2, AddressZipCode }.Any(addressField => !string.IsNullOrEmpty(addressField));
-
-            if (isAddressSpecified)
-            {
-                target.Addresses.Add(new Address
-                {
-                    AddressType = !string.IsNullOrEmpty(AddressType) ? Enum.Parse<AddressType>(AddressType) : CoreModule.Core.Common.AddressType.BillingAndShipping,
-                    FirstName = AddressFirstName,
-                    LastName = AddressLastName,
-                    CountryName = AddressCountry,
-                    CountryCode = AddressCountryCode,
-                    RegionName = AddressRegion,
-                    City = AddressCity,
-                    Line1 = AddressLine1,
-                    Line2 = AddressLine2,
-                    PostalCode = AddressZipCode,
-                    Email = AddressEmail,
-                    Phone = AddressPhone,
-                });
-            }
+            PatchAddresses(target);
         }
     }
 }

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportableOrganization.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportableOrganization.cs
@@ -2,32 +2,62 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using CsvHelper.Configuration.Attributes;
+using Newtonsoft.Json;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.CustomerModule.Core.Model;
 using Address = VirtoCommerce.CustomerModule.Core.Model.Address;
 
 namespace VirtoCommerce.CustomerExportImportModule.Core.Models
 {
-    public sealed class ImportableOrganization : CsvOrganization
+    public sealed class ImportableOrganization : CsvOrganization, IImportable
     {
+        [Ignore, JsonIgnore]
+        public string RecordName
+        {
+            get => OrganizationName;
+            set => OrganizationName = value;
+        }
+
+        [Optional]
+        [Name("Parent Organization Id")]
+        public string ParentOrganizationId { get; set; }
+
+        [Optional]
+        [Name("Parent Organization Outer Id")]
+        public string ParentOrganizationOuterId { get; set; }
+
+        [Optional]
+        [Name("Parent Organization Name")]
+        public string ParentOrganizationName { get; set; }
+
+        [Optional]
+        [Name("Organization Groups")]
+        public string OrganizationGroups { get; set; }
+
         /// <summary>
         /// 'Address Country' from file is not used. It will be set at import process from ISO countries dictionary
         /// by 'Address Code' field. Therefore it is ignored.
         /// </summary>
-        [Ignore]
+        [Ignore, JsonIgnore]
         [Name("Address Country")]
         public override string AddressCountry { get; set; }
 
         public void PatchModel(Organization target)
         {
-            target.OuterId = OuterId;
-            target.Name = OrganizationName;
-            target.Emails = string.IsNullOrEmpty(Emails) ? null : Emails.Split(',').Select(email => email.Trim()).ToList();
-            target.Phones = string.IsNullOrEmpty(Phones) ? null : Phones.Split(',').Select(phone => phone.Trim()).ToList();
-            target.BusinessCategory = BusinessCategory;
-            target.Description = Description;
+            if (AdditionalLine != true)
+            {
+                target.OuterId = OuterId;
+                target.Name = OrganizationName;
+                target.BusinessCategory = BusinessCategory;
+                target.Description = Description;
 
-            PatchDynamicProperties(target);
+                const StringSplitOptions splitOptions = StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries;
+                target.Emails = string.IsNullOrEmpty(Emails) ? null : Emails.Split(',', splitOptions);
+                target.Phones = string.IsNullOrEmpty(Phones) ? null : Phones.Split(',', splitOptions);
+                target.Groups = string.IsNullOrEmpty(OrganizationGroups) ? null : OrganizationGroups.Split(',', splitOptions);
+
+                PatchDynamicProperties(target);
+            }
 
             target.Addresses ??= new List<Address>();
             var isAddressSpecified = new[] { AddressCountry, AddressCountryCode, AddressRegion, AddressCity, AddressLine1, AddressLine2, AddressZipCode }.Any(addressField => !string.IsNullOrEmpty(addressField));

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/ModuleConstants.cs
@@ -16,6 +16,8 @@ namespace VirtoCommerce.CustomerExportImportModule.Core
         {
             public const string DuplicateError = "Duplicate";
 
+            public const string WrongAdditionalLine = "wrong-additional-line";
+
             public const string FileNotExisted = "file-not-existed";
 
             public const string NoData = "no-data";

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/VirtoCommerce.CustomerExportImportModule.Core.csproj
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/VirtoCommerce.CustomerExportImportModule.Core.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="Nager.Country" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.200.0" />
-        <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.211.0" />
+        <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.219.0" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.253.0" />
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.206.0" />
     </ItemGroup>

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Services/CsvPagedContactDataImporter.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Services/CsvPagedContactDataImporter.cs
@@ -90,11 +90,11 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Services
 
             PatchExistedContacts(existedContacts, updateImportContacts, existedOrganizations, request.OrganizationId);
 
-            var contactsForSave = newContacts.Union(existedContacts).ToArray();
+            var saveContacts = newContacts.Union(existedContacts).ToArray();
 
-            await _memberService.SaveChangesAsync(contactsForSave);
+            await _memberService.SaveChangesAsync(saveContacts);
 
-            await CreateAccountsForContacts(contactsForSave);
+            await CreateAccountsForContacts(saveContacts);
 
             importProgress.CreatedCount += newContacts.Length;
             importProgress.AdditionalLineCount += createImportContacts.Length - newContacts.Length;

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Services/CsvPagedContactDataImporter.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Services/CsvPagedContactDataImporter.cs
@@ -81,7 +81,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Services
                 .Where(x => !string.IsNullOrEmpty(x)).ToArray();
 
             var existedOrganizations =
-                (await SearchMembersByIdAndOuterIdAsync(internalOrgIds, outerOrgIds, new[] { nameof(Organization) }))
+                (await SearchMembersByIdAndOuterIdAsync(internalOrgIds, outerOrgIds, new[] { nameof(Organization) }, true))
                 .OfType<Organization>().ToArray();
 
             var newContacts = CreateNewContacts(createImportContacts, existedOrganizations, request.OrganizationId);

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Services/CsvPagedDataImporter.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Services/CsvPagedDataImporter.cs
@@ -167,16 +167,14 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Services
         /// </summary>
         /// <param name="importMembers"></param>
         /// <param name="existedMembers"></param>
-        protected static void SetIdToNullForNotExisted(ImportRecord<TCsvMember>[] importMembers, TMember[] existedMembers)
+        protected virtual void SetIdToNullForNotExisted(ImportRecord<TCsvMember>[] importMembers, TMember[] existedMembers)
         {
-            foreach (var importContact in importMembers)
+            foreach (var importMember in importMembers)
             {
-                var existedMember =
-                    existedMembers.FirstOrDefault(x => x.Id.EqualsInvariant(importContact.Record.Id));
-
+                var existedMember = existedMembers.FirstOrDefault(x => x.Id.EqualsInvariant(importMember.Record.Id));
                 if (existedMember == null)
                 {
-                    importContact.Record.Id = null;
+                    importMember.Record.Id = null;
                 }
             }
         }
@@ -187,16 +185,14 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Services
         /// </summary>
         /// <param name="importMembers"></param>
         /// <param name="existedMembers"></param>
-        protected static void SetIdToRealForExistedOuterId(ImportRecord<TCsvMember>[] importMembers, TMember[] existedMembers)
+        protected virtual void SetIdToRealForExistedOuterId(ImportRecord<TCsvMember>[] importMembers, TMember[] existedMembers)
         {
-            foreach (var importContact in importMembers.Where(x => string.IsNullOrEmpty(x.Record.Id) && !string.IsNullOrEmpty(x.Record.OuterId)))
+            foreach (var importMember in importMembers.Where(x => string.IsNullOrEmpty(x.Record.Id) && !string.IsNullOrEmpty(x.Record.OuterId)))
             {
-                var existedMember =
-                    existedMembers.FirstOrDefault(x => !string.IsNullOrEmpty(x.OuterId) && x.OuterId.EqualsInvariant(importContact.Record.OuterId));
-
+                var existedMember = existedMembers.FirstOrDefault(x => !string.IsNullOrEmpty(x.OuterId) && x.OuterId.EqualsInvariant(importMember.Record.OuterId));
                 if (existedMember != null)
                 {
-                    importContact.Record.Id = existedMember.Id;
+                    importMember.Record.Id = existedMember.Id;
                 }
             }
         }

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Services/CustomerExportPagedDataSource.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Services/CustomerExportPagedDataSource.cs
@@ -6,6 +6,7 @@ using VirtoCommerce.CustomerExportImportModule.Core.Models;
 using VirtoCommerce.CustomerExportImportModule.Core.Services;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.StoreModule.Core.Services;
@@ -88,7 +89,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Services
             // Get stores from accounts
             var accounts = contacts.Select(contact => contact.SecurityAccounts?.MinBy(account => account.Id)).Where(account => account != null).Distinct().ToArray();
             var storeIds = accounts.Select(account => account.StoreId).Where(storeId => !string.IsNullOrEmpty(storeId)).Distinct().ToList();
-            var stores = (await _storeService.GetAsync(storeIds, StoreResponseGroup.None.ToString())).ToDictionary(store => store.Id, store => store);
+            var stores = (await _storeService.GetAsync(storeIds, StoreResponseGroup.None.ToString())).ToDictionary(store => store.Id, store => store).WithDefaultValue(null);
 
             Items = searchResult.Results.Select<Member, IExportable>(member =>
             {
@@ -101,7 +102,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Services
                         var storeId = account?.StoreId;
                         return new ExportableContact().FromModels(contact,
                             organizationId != null && allOrganizations.ContainsKey(organizationId) ? allOrganizations[organizationId] : null,
-                            storeId != null && stores.ContainsKey(storeId) ? stores[storeId] : null);
+                            storeId != null ? stores[storeId] : null);
                     case nameof(Organization):
                         var organization = (Organization)member;
                         var parentOrganizationId = organization.ParentId;

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Services/ExportImportMemberSearchService.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Services/ExportImportMemberSearchService.cs
@@ -7,7 +7,6 @@ using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Model.Search;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.CustomerModule.Core.Services.Indexed;
-using VirtoCommerce.CustomerModule.Data.Model;
 using VirtoCommerce.CustomerModule.Data.Repositories;
 using VirtoCommerce.CustomerModule.Data.Services;
 using VirtoCommerce.Platform.Core.Caching;
@@ -76,18 +75,6 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Services
             result.Results = result.Results.Skip(orgSkip).Take(orgTake).ToList();
 
             return result;
-        }
-
-        protected override IQueryable<MemberEntity> BuildQuery(IMemberRepository repository, MembersSearchCriteria criteria)
-        {
-            var query = base.BuildQuery(repository, criteria);
-
-            if (criteria is ExtendedMembersSearchCriteria extendedCriteria && !extendedCriteria.OuterIds.IsNullOrEmpty())
-            {
-                query = query.Where(m => extendedCriteria.OuterIds.Contains(m.OuterId));
-            }
-
-            return query;
         }
 
         protected virtual async Task LoadChildren(MembersSearchCriteria criteria, IEnumerable<Organization> organizations, bool withoutOrganizations, string[] orgMemberTypes, MemberSearchResult result)

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
@@ -36,12 +36,13 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
 
         private void AttachValidators()
         {
-            When(x => new[]
-                {
-                    x.Record.AccountType, x.Record.AccountStatus, x.Record.AccountLogin, x.Record.AccountEmail, x.Record.StoreId, x.Record.StoreName,
-                    x.Record.EmailVerified.ToString()
-                }.Any(field => !string.IsNullOrEmpty(field))
-                , () =>
+            When(x => x.Record.AdditionalLine != true
+                      && new[]
+                      {
+                          x.Record.AccountType, x.Record.AccountStatus, x.Record.AccountLogin, x.Record.AccountEmail, x.Record.StoreId, x.Record.StoreName,
+                          x.Record.EmailVerified.ToString()
+                      }.Any(field => !string.IsNullOrEmpty(field)),
+                () =>
                 {
 
                     RuleFor(x => x.Record.AccountLogin)
@@ -53,9 +54,14 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                             RuleFor(x => x.Record.AccountLogin)
                                 .MustAsync(async (thisRecord, userName, _) =>
                                 {
-                                    var lastRecordWithAccountLogin = _allRecords.LastOrDefault(otherRecord => userName.EqualsInvariant(otherRecord.Record.AccountLogin));
+                                    var lastRecordWithAccountLogin = _allRecords
+                                        .Where(x => x.Record.AdditionalLine != true)
+                                        .LastOrDefault(otherRecord => userName.EqualsInvariant(otherRecord.Record.AccountLogin));
                                     return await _userManager.FindByNameAsync(userName) == null &&
-                                           (_allRecords.All(otherRecord => !userName.EqualsInvariant(otherRecord.Record.AccountLogin)) || lastRecordWithAccountLogin == thisRecord);
+                                           (_allRecords
+                                               .Where(x => x.Record.AdditionalLine != true)
+                                               .All(otherRecord => !userName.EqualsInvariant(otherRecord.Record.AccountLogin))
+                                            || lastRecordWithAccountLogin == thisRecord);
                                 })
                                 .WithNotUniqueValueCodeAndMessage("Account Login")
                                 .WithImportState();
@@ -75,9 +81,14 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                                     RuleFor(x => x.Record.AccountEmail)
                                         .MustAsync(async (thisRecord, email, _) =>
                                         {
-                                            var lastRecordWithAccountEmail = _allRecords.LastOrDefault(otherRecord => email.EqualsInvariant(otherRecord.Record.AccountEmail));
+                                            var lastRecordWithAccountEmail = _allRecords
+                                                .Where(x => x.Record.AdditionalLine != true)
+                                                .LastOrDefault(otherRecord => email.EqualsInvariant(otherRecord.Record.AccountEmail));
                                             return await _userManager.FindByEmailAsync(email) == null &&
-                                                   (_allRecords.All(otherRecord => !email.EqualsInvariant(otherRecord.Record.AccountEmail)) || lastRecordWithAccountEmail == thisRecord);
+                                                   (_allRecords
+                                                       .Where(x => x.Record.AdditionalLine != true)
+                                                       .All(otherRecord => !email.EqualsInvariant(otherRecord.Record.AccountEmail))
+                                                    || lastRecordWithAccountEmail == thisRecord);
                                         })
                                         .WithNotUniqueValueCodeAndMessage("Account Email")
                                         .WithImportState();

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAddressValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAddressValidator.cs
@@ -34,17 +34,11 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                         .WithImportState();
 
                     RuleFor(x => x.Record.AddressFirstName).Cascade(CascadeMode.Stop)
-                        .NotEmpty()
-                        .WithMissingRequiredValueCodeAndMessage("Address First Name")
-                        .WithImportState()
                         .MaximumLength(128)
                         .WithExceededMaxLengthCodeAndMessage("Address First Name", 128)
                         .WithImportState();
 
                     RuleFor(x => x.Record.AddressLastName).Cascade(CascadeMode.Stop)
-                        .NotEmpty()
-                        .WithMissingRequiredValueCodeAndMessage("Address Last Name")
-                        .WithImportState()
                         .MaximumLength(128)
                         .WithExceededMaxLengthCodeAndMessage("Address Last Name", 128)
                         .WithImportState();

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactValidator.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Identity;
 using VirtoCommerce.CustomerExportImportModule.Core.Models;
 using VirtoCommerce.CustomerExportImportModule.Data.Helpers;
+using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.StoreModule.Core.Services;
@@ -12,14 +13,16 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IPasswordValidator<ApplicationUser> _passwordValidator;
+        private readonly IMemberService _memberService;
         private readonly IStoreSearchService _storeSearchService;
         private readonly ISettingsManager _settingsManager;
         private readonly ImportRecord<ImportableContact>[] _allRecords;
 
-        public ImportContactValidator(UserManager<ApplicationUser> userManager, IPasswordValidator<ApplicationUser> passwordValidator, IStoreSearchService storeSearchService, ISettingsManager settingsManager, ImportRecord<ImportableContact>[] allRecords)
+        public ImportContactValidator(UserManager<ApplicationUser> userManager, IPasswordValidator<ApplicationUser> passwordValidator, IMemberService memberService, IStoreSearchService storeSearchService, ISettingsManager settingsManager, ImportRecord<ImportableContact>[] allRecords)
         {
             _userManager = userManager;
             _passwordValidator = passwordValidator;
+            _memberService = memberService;
             _storeSearchService = storeSearchService;
             _settingsManager = settingsManager;
             _allRecords = allRecords;
@@ -124,7 +127,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                 .WithExceededMaxLengthCodeAndMessage("Preferred Communication", 64)
                 .WithImportState();
 
-            RuleFor(x => x).SetValidator(_ => new ImportAccountValidator(_userManager, _passwordValidator, _storeSearchService, _settingsManager, _allRecords));
+            RuleFor(x => x).SetValidator(_ => new ImportAccountValidator(_userManager, _passwordValidator, _memberService, _storeSearchService, _settingsManager, _allRecords));
         }
     }
 }

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactValidator.cs
@@ -28,6 +28,11 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
 
         private void AttachValidators()
         {
+            RuleFor(x => x.Record.Id)
+                .MaximumLength(128)
+                .WithExceededMaxLengthCodeAndMessage("Contact Id", 128)
+                .WithImportState();
+
             RuleFor(x => x.Record.OuterId)
                 .MaximumLength(128)
                 .WithExceededMaxLengthCodeAndMessage("Contact Outer Id", 128)
@@ -69,10 +74,16 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                         .WithImportState();
                 });
 
+            RuleFor(x => x.Record.OrganizationId)
+                .MaximumLength(128)
+                .WithExceededMaxLengthCodeAndMessage("Organization Id", 128)
+                .WithImportState();
+
             RuleFor(x => x.Record.OrganizationOuterId)
                 .MaximumLength(128)
                 .WithExceededMaxLengthCodeAndMessage("Organization Outer Id", 128)
                 .WithImportState();
+
             RuleFor(x => x.Record.OrganizationName)
                 .MaximumLength(128)
                 .WithExceededMaxLengthCodeAndMessage("Organization Name", 128)
@@ -82,26 +93,32 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                 .MaximumLength(64)
                 .WithExceededMaxLengthCodeAndMessage("Contact Status", 64)
                 .WithImportState();
+
             RuleFor(x => x.Record.TimeZone)
                 .MaximumLength(32)
                 .WithExceededMaxLengthCodeAndMessage("Time Zone", 32)
                 .WithImportState();
+
             RuleFor(x => x.Record.Salutation)
                 .MaximumLength(256)
                 .WithExceededMaxLengthCodeAndMessage("Salutation", 256)
                 .WithImportState();
+
             RuleFor(x => x.Record.DefaultLanguage)
                 .MaximumLength(32)
                 .WithExceededMaxLengthCodeAndMessage("Default Language", 32)
                 .WithImportState();
+
             RuleFor(x => x.Record.TaxPayerId)
                 .MaximumLength(64)
                 .WithExceededMaxLengthCodeAndMessage("Tax Payer Id", 64)
                 .WithImportState();
+
             RuleFor(x => x.Record.PreferredDelivery)
                 .MaximumLength(64)
                 .WithExceededMaxLengthCodeAndMessage("Preferred Delivery", 64)
                 .WithImportState();
+
             RuleFor(x => x.Record.PreferredCommunication)
                 .MaximumLength(64)
                 .WithExceededMaxLengthCodeAndMessage("Preferred Communication", 64)

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactsValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactsValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using Microsoft.AspNetCore.Identity;
 using VirtoCommerce.CustomerExportImportModule.Core.Models;
+using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Security;
@@ -15,17 +16,19 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
         private readonly IDynamicPropertyDictionaryItemsSearchService _dynamicPropertyDictionaryItemsSearchService;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly IPasswordValidator<ApplicationUser> _passwordValidator;
+        private readonly IMemberService _memberService;
         private readonly IStoreSearchService _storeSearchService;
         private readonly ISettingsManager _settingsManager;
 
         public ImportContactsValidator(ICountriesService countriesService, IDynamicPropertyDictionaryItemsSearchService dynamicPropertyDictionaryItemsSearchService,
-            SignInManager<ApplicationUser> signInManager, IPasswordValidator<ApplicationUser> passwordValidator,
+            SignInManager<ApplicationUser> signInManager, IPasswordValidator<ApplicationUser> passwordValidator, IMemberService memberService,
             IStoreSearchService storeSearchService, ISettingsManager settingsManager)
         {
             _countriesService = countriesService;
             _dynamicPropertyDictionaryItemsSearchService = dynamicPropertyDictionaryItemsSearchService;
             _signInManager = signInManager;
             _passwordValidator = passwordValidator;
+            _memberService = memberService;
             _storeSearchService = storeSearchService;
             _settingsManager = settingsManager;
 
@@ -37,7 +40,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
             RuleFor(importRecords => importRecords).SetValidator(_ => new ImportEntitiesAreNotDuplicatesValidator<ImportableContact>());
             RuleFor(importRecords => importRecords).SetValidator(_ => new ImportEntitiesAdditionalLinesValidator<ImportableContact>());
             RuleForEach(importRecords => importRecords).SetValidator(new ImportMemberValidator<ImportableContact>(_countriesService, _dynamicPropertyDictionaryItemsSearchService));
-            RuleForEach(importRecords => importRecords).SetValidator(allRecords => new ImportContactValidator(_signInManager.UserManager, _passwordValidator, _storeSearchService, _settingsManager, allRecords));
+            RuleForEach(importRecords => importRecords).SetValidator(allRecords => new ImportContactValidator(_signInManager.UserManager, _passwordValidator, _memberService, _storeSearchService, _settingsManager, allRecords));
         }
     }
 }

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactsValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactsValidator.cs
@@ -35,6 +35,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
         private void AttachValidators()
         {
             RuleFor(importRecords => importRecords).SetValidator(_ => new ImportEntitiesAreNotDuplicatesValidator<ImportableContact>());
+            RuleFor(importRecords => importRecords).SetValidator(_ => new ImportEntitiesAdditionalLinesValidator<ImportableContact>());
             RuleForEach(importRecords => importRecords).SetValidator(new ImportMemberValidator<ImportableContact>(_countriesService, _dynamicPropertyDictionaryItemsSearchService));
             RuleForEach(importRecords => importRecords).SetValidator(allRecords => new ImportContactValidator(_signInManager.UserManager, _passwordValidator, _storeSearchService, _settingsManager, allRecords));
         }

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportEntitiesAdditionalLinesValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportEntitiesAdditionalLinesValidator.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using FluentValidation;
+using VirtoCommerce.CustomerExportImportModule.Core.Models;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
+{
+    public sealed class ImportEntitiesAdditionalLinesValidator<T> : AbstractValidator<ImportRecord<T>[]>
+        where T : IEntity, IHasOuterId, IImportable
+    {
+        internal const string WrongAdditionalLines = nameof(WrongAdditionalLines);
+
+        public ImportEntitiesAdditionalLinesValidator()
+        {
+            AttachValidators();
+        }
+
+        private void AttachValidators()
+        {
+            RuleFor(importRecord => importRecord)
+                .Custom(GetWrongAdditionalLines)
+                .ForEach(rule => rule.SetValidator(_ => new ImportEntityAdditionalLineValidator<T>()));
+        }
+
+        private static void GetWrongAdditionalLines(ImportRecord<T>[] importRecords, ValidationContext<ImportRecord<T>[]> context)
+        {
+            context.RootContextData[WrongAdditionalLines] = importRecords
+                .GroupBy(importRecord => (importRecord.Record.Id, importRecord.Record.OuterId, importRecord.Record.RecordName))
+                .Where(group => group.All(x => x.Record.AdditionalLine == true))
+                .SelectMany(group => group)
+                .ToArray();
+        }
+    }
+}

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportEntitiesAreNotDuplicatesValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportEntitiesAreNotDuplicatesValidator.cs
@@ -6,7 +6,7 @@ using VirtoCommerce.Platform.Core.Common;
 namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
 {
     public sealed class ImportEntitiesAreNotDuplicatesValidator<T> : AbstractValidator<ImportRecord<T>[]>
-        where T : IEntity, IHasOuterId
+        where T : IEntity, IHasOuterId, IImportable
     {
         internal const string Duplicates = nameof(Duplicates);
 
@@ -24,12 +24,14 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
 
         private static void GetDuplicates(ImportRecord<T>[] importRecords, ValidationContext<ImportRecord<T>[]> context)
         {
-            var duplicatesById = importRecords.Where(importRecord => !string.IsNullOrEmpty(importRecord.Record.Id))
+            var duplicatesById = importRecords
+                .Where(importRecord => !string.IsNullOrEmpty(importRecord.Record.Id) && importRecord.Record.AdditionalLine != true)
                 .GroupBy(importRecord => importRecord.Record.Id)
                 .SelectMany(group => group.Take(group.Count() - 1))
                 .ToArray();
 
-            var duplicatesByOuterId = importRecords.Where(importRecord => !string.IsNullOrEmpty(importRecord.Record.OuterId))
+            var duplicatesByOuterId = importRecords
+                .Where(importRecord => !string.IsNullOrEmpty(importRecord.Record.OuterId) && importRecord.Record.AdditionalLine != true)
                 .GroupBy(importRecord => importRecord.Record.OuterId)
                 .SelectMany(group => group.Take(group.Count() - 1))
                 .ToArray();

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportEntityAdditionalLineValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportEntityAdditionalLineValidator.cs
@@ -7,10 +7,10 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
 {
-    public sealed class ImportEntityIsNotDuplicateValidator<T>: AbstractValidator<ImportRecord<T>>
+    public sealed class ImportEntityAdditionalLineValidator<T>: AbstractValidator<ImportRecord<T>>
         where T: IEntity, IHasOuterId, IImportable
     {
-        public ImportEntityIsNotDuplicateValidator()
+        public ImportEntityAdditionalLineValidator()
         {
             AttachValidators();
         }
@@ -20,11 +20,11 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
             RuleFor(importRecord => importRecord)
                 .Must((_, importRecord, context) =>
                 {
-                    var duplicates = (ImportRecord<T>[])context.RootContextData[ImportEntitiesAreNotDuplicatesValidator<T>.Duplicates];
-                    return !duplicates.Contains(importRecord);
+                    var wrongLines = (ImportRecord<T>[])context.RootContextData[ImportEntitiesAdditionalLinesValidator<T>.WrongAdditionalLines];
+                    return !wrongLines.Contains(importRecord);
                 })
-                .WithErrorCode(ModuleConstants.ValidationErrors.DuplicateError)
-                .WithMessage("This customer is a duplicate.")
+                .WithErrorCode(ModuleConstants.ValidationErrors.WrongAdditionalLine)
+                .WithMessage("This customer's additional line doesn't have corresponding main line.")
                 .WithImportState();
         }
     }

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportOrganizationValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportOrganizationValidator.cs
@@ -29,10 +29,25 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                         .WithExceededMaxLengthCodeAndMessage("Organization Name", 128)
                         .WithImportState();
                 });
-            
+
+            RuleFor(x => x.Record.ParentOrganizationOuterId)
+                .MaximumLength(128)
+                .WithExceededMaxLengthCodeAndMessage("Parent Organization Outer Id", 128)
+                .WithImportState();
+
+            RuleFor(x => x.Record.ParentOrganizationName)
+                .MaximumLength(128)
+                .WithExceededMaxLengthCodeAndMessage("Parent Organization Name", 128)
+                .WithImportState();
+
             RuleFor(x => x.Record.BusinessCategory)
                 .MaximumLength(64)
                 .WithExceededMaxLengthCodeAndMessage("Business Category", 64)
+                .WithImportState();
+
+            RuleFor(x => x.Record.OrganizationGroups)
+                .MaximumLength(64)
+                .WithExceededMaxLengthCodeAndMessage("Organization Groups", 64)
                 .WithImportState();
         }
     }

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportOrganizationValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportOrganizationValidator.cs
@@ -13,6 +13,11 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
 
         private void AttachValidators()
         {
+            RuleFor(x => x.Record.Id)
+                .MaximumLength(128)
+                .WithExceededMaxLengthCodeAndMessage("Organization Id", 128)
+                .WithImportState();
+
             RuleFor(x => x.Record.OuterId)
                 .MaximumLength(128)
                 .WithExceededMaxLengthCodeAndMessage("Organization Outer Id", 128)
@@ -29,6 +34,11 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                         .WithExceededMaxLengthCodeAndMessage("Organization Name", 128)
                         .WithImportState();
                 });
+
+            RuleFor(x => x.Record.ParentOrganizationId)
+                .MaximumLength(128)
+                .WithExceededMaxLengthCodeAndMessage("Parent Organization Id", 128)
+                .WithImportState();
 
             RuleFor(x => x.Record.ParentOrganizationOuterId)
                 .MaximumLength(128)

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportOrganizationsValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportOrganizationsValidator.cs
@@ -20,6 +20,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
         private void AttachValidators()
         {
             RuleFor(importRecords => importRecords).SetValidator(_ => new ImportEntitiesAreNotDuplicatesValidator<ImportableOrganization>());
+            RuleFor(importRecords => importRecords).SetValidator(_ => new ImportEntitiesAdditionalLinesValidator<ImportableOrganization>());
             RuleForEach(importRecords => importRecords).SetValidator(new ImportMemberValidator<ImportableOrganization>(_countriesService, _dynamicPropertyDictionaryItemsSearchService));
             RuleForEach(importRecords => importRecords).SetValidator(new ImportOrganizationValidator());
         }

--- a/src/VirtoCommerce.CustomerExportImportModule.Web/Localizations/en.VirtoCommerce.CustomerExportImport.json
+++ b/src/VirtoCommerce.CustomerExportImportModule.Web/Localizations/en.VirtoCommerce.CustomerExportImport.json
@@ -89,8 +89,8 @@
       "customer-import": {
         "title-contacts": "Import contacts",
         "title-organizations": "Import organizations",
-        "contacts": "contacts",
-        "organizations": "organizations",
+        "contacts": "lines of contacts",
+        "organizations": "lines of organizations",
         "main-text-middle": "will be imported into the",
         "root": "root",
         "current-organization": "current organization",

--- a/src/VirtoCommerce.CustomerExportImportModule.Web/Properties/launchSettings.json
+++ b/src/VirtoCommerce.CustomerExportImportModule.Web/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "VirtoCommerce.QuoteModule.Web": {
+    "VirtoCommerce.CustomerExportImportModule.Web": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/src/VirtoCommerce.CustomerExportImportModule.Web/module.manifest
+++ b/src/VirtoCommerce.CustomerExportImportModule.Web/module.manifest
@@ -21,7 +21,7 @@
   <assemblyFile>VirtoCommerce.CustomerExportImportModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.CustomerExportImportModule.Web.Module, VirtoCommerce.CustomerExportImportModule.Web</moduleType>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.211.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.219.0" />
     <dependency id="VirtoCommerce.Store" version="3.206.0" />
   </dependencies>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>

--- a/tests/VirtoCommerce.CustomerExportImportModule.Tests/CsvClassMapsTest.cs
+++ b/tests/VirtoCommerce.CustomerExportImportModule.Tests/CsvClassMapsTest.cs
@@ -128,9 +128,9 @@ namespace VirtoCommerce.CustomerExportImportModule.Tests
             Name = "b2b-store"
         };
 
-        private const string ContactCsvHeader = "Contact Id;Contact Outer Id;Contact First Name;Contact Last Name;Contact Full Name;Organization Id;Organization Outer Id;Organization Name;Contact Status;Contact Emails;Contact Phones;Contact Salutation;Contact Birthday;Contact TimeZone;Contact Default language;Contact Taxpayer ID;Contact Preferred communication;Contact Preferred delivery;Contact Associated Organization Ids;Contact User groups;Address Type;Address First Name;Address Last Name;Address Country;Address Country Code;Address Region;Address City;Address Line1;Address Line2;Address Zip Code;Address Email;Address Phone;Account Id;Account Login;Account Store Id;Account Store Name;Account Email;Account Type;Account Status;Account Email Verified;Sex;Job";
+        private const string ContactCsvHeader = "Contact Id;Contact Outer Id;Contact First Name;Contact Last Name;Contact Full Name;Organization Id;Organization Outer Id;Organization Name;Contact Status;Contact Emails;Contact Phones;Contact Salutation;Contact Birthday;Contact TimeZone;Contact Default language;Contact Taxpayer ID;Contact Preferred communication;Contact Preferred delivery;Contact Associated Organization Ids;Contact User groups;Address Type;Address First Name;Address Last Name;Address Country;Address Country Code;Address Region;Address City;Address Line1;Address Line2;Address Zip Code;Address Email;Address Phone;Account Id;Account Login;Account Store Id;Account Store Name;Account Email;Account Type;Account Status;Account Email Verified;Additional Line;Sex;Job";
 
-        private const string ContactCsvRecord = "contact_id;outer_id;Anton;Boroda;Anton Boroda;org_id;org_outer_id;Boroda ltd;new;boroda@ya.ru;777, 555;mr;04/14/1986 00:00:00;MSK;en_US;TaxId;email;pickup;org_id1, org_id2;tag1, tag2;Pickup;Anton;Boroda;Russia;RUS;Kirov region;Kirov;1 st;169;610033;c@mail.com;777;account_id;login;b2b-store;b2b-store;c@mail.com;customer;new;True;Male;Developer";
+        private const string ContactCsvRecord = "contact_id;outer_id;Anton;Boroda;Anton Boroda;org_id;org_outer_id;Boroda ltd;new;boroda@ya.ru;777, 555;mr;04/14/1986 00:00:00;MSK;en_US;TaxId;email;pickup;org_id1, org_id2;tag1, tag2;Pickup;Anton;Boroda;Russia;RUS;Kirov region;Kirov;1 st;169;610033;c@mail.com;777;account_id;login;b2b-store;b2b-store;c@mail.com;customer;new;True;;Male;Developer";
 
         [Fact]
         public void Export_ContactWithDynamicProperty_HeaderAndValuesAreCorrect()
@@ -231,8 +231,8 @@ namespace VirtoCommerce.CustomerExportImportModule.Tests
             stream.Seek(0, SeekOrigin.Begin);
 
             //Assert
-            const string expected = "Organization Id;Organization Outer Id;Organization Name;Parent Organization Name;Parent Organization Id;Parent Organization Outer Id;Business category;Description;Organization Groups;Emails;Phones;Address Type;Address First Name;Address Last Name;Address Country;Address Country Code;Address Region;Address City;Address Line1;Address Line2;Address Zip Code;Address Email;Address Phone;Size\r\n"
-                                    + "org_id1;OuterId1;Boroda ltd;parent_outer_id;parent_otg_id;parent_outer_id;Market Place;org desc;tag1, tag2;;777, 555;Pickup;Anton;Boroda;Russia;RUS;Kirov region;Kirov;1 st;169;610033;c@mail.com;777;Huge\r\n";
+            const string expected = "Organization Id;Organization Outer Id;Organization Name;Parent Organization Name;Parent Organization Id;Parent Organization Outer Id;Business category;Description;Organization Groups;Emails;Phones;Address Type;Address First Name;Address Last Name;Address Country;Address Country Code;Address Region;Address City;Address Line1;Address Line2;Address Zip Code;Address Email;Address Phone;Additional Line;Size\r\n"
+                                    + "org_id1;OuterId1;Boroda ltd;parent_outer_id;parent_otg_id;parent_outer_id;Market Place;org desc;tag1, tag2;;777, 555;Pickup;Anton;Boroda;Russia;RUS;Kirov region;Kirov;1 st;169;610033;c@mail.com;777;;Huge\r\n";
 
             var sr = new StreamReader(stream);
             var csv = sr.ReadToEnd();


### PR DESCRIPTION
## Description
- First Name, Last Name of address should not be required in Import organizations/contacts as it's not required in admin backend 
- Should be supported Import case when one organization has several Shipping addresses or Billing addresses and it can be imported by one file
- Should be supported Import case when organizations have child organizations, it's related by outer ID and it can be imported by one file
- Update contact by outerId only with loading data without accounts
## References
### QA-test:
### Jira-link:
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CustomerExportImport_3.202.0-pr-78-ec6c.zip
