### PR TITLE
fix: Add StoreId validation to check wrong case issue

### DIFF
--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
@@ -131,8 +131,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                 {
                     var contact = new Contact();
                     thisRecord.Record.PatchModel(contact);
-                    var user = contact.SecurityAccounts?.FirstOrDefault();
-                    return user is null || await _passwordValidator.ValidateAsync(_userManager, user, password) == IdentityResult.Success;
+                    return await _passwordValidator.ValidateAsync(_userManager, contact.SecurityAccounts.FirstOrDefault(), password) == IdentityResult.Success;
                 })
                 .When(x => !string.IsNullOrEmpty(x.Record.Password))
                 .WithErrorCode(ModuleConstants.ValidationErrors.PasswordDoesntMeetSecurityPolicy)

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
@@ -123,7 +123,6 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                             if (storeSearchResult.TotalCount == 0)
                             {
                                 return false;
-
                             }
 
                             //Need to check for case-sensitive equality

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
@@ -116,11 +116,23 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                 .DependentRules(() =>
                 {
                     RuleFor(x => x.Record.StoreId)
-                        .MustAsync(async (storeId, _) =>
+                        .MustAsync(async (thisRecord, storeId, _) =>
                         {
                             var storeSearchResult = await _storeSearchService.SearchAsync(new StoreSearchCriteria { ObjectIds = new[] { storeId }, Take = 1 }, false);
+
+                            if (storeSearchResult.TotalCount == 0)
+                            {
+                                return false;
+
+                            }
+
                             //Need to check for case-sensitive equality
-                            return storeSearchResult.Results.FirstOrDefault()?.Id == storeId;
+                            if (!StringComparer.Ordinal.Equals(storeSearchResult.Results.FirstOrDefault()?.Id, storeId))
+                            {
+                                thisRecord.Record.StoreId = storeSearchResult.Results.FirstOrDefault()?.Id;
+                            }
+
+                            return true;
                         })
                         .WithInvalidValueCodeAndMessage("Store Id")
                         .WithImportState();

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportAccountValidator.cs
@@ -118,8 +118,9 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                     RuleFor(x => x.Record.StoreId)
                         .MustAsync(async (storeId, _) =>
                         {
-                            var storeSearchResult = await _storeSearchService.SearchAsync(new StoreSearchCriteria { ObjectIds = new[] { storeId }, Take = 0 }, false);
-                            return storeSearchResult.TotalCount == 1;
+                            var storeSearchResult = await _storeSearchService.SearchAsync(new StoreSearchCriteria { ObjectIds = new[] { storeId }, Take = 1 }, false);
+
+                            return (storeSearchResult.TotalCount == 1 && storeSearchResult.Results.First().Id == storeId);
                         })
                         .WithInvalidValueCodeAndMessage("Store Id")
                         .WithImportState();

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactValidator.cs
@@ -9,21 +9,21 @@ using VirtoCommerce.StoreModule.Core.Services;
 
 namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
 {
-    public class ImportContactValidator: AbstractValidator<ImportRecord<ImportableContact>>
+    public class ImportContactValidator : AbstractValidator<ImportRecord<ImportableContact>>
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IPasswordValidator<ApplicationUser> _passwordValidator;
         private readonly IMemberService _memberService;
-        private readonly IStoreSearchService _storeSearchService;
+        private readonly IStoreService _storeService;
         private readonly ISettingsManager _settingsManager;
         private readonly ImportRecord<ImportableContact>[] _allRecords;
 
-        public ImportContactValidator(UserManager<ApplicationUser> userManager, IPasswordValidator<ApplicationUser> passwordValidator, IMemberService memberService, IStoreSearchService storeSearchService, ISettingsManager settingsManager, ImportRecord<ImportableContact>[] allRecords)
+        public ImportContactValidator(UserManager<ApplicationUser> userManager, IPasswordValidator<ApplicationUser> passwordValidator, IMemberService memberService, IStoreService storeService, ISettingsManager settingsManager, ImportRecord<ImportableContact>[] allRecords)
         {
             _userManager = userManager;
             _passwordValidator = passwordValidator;
             _memberService = memberService;
-            _storeSearchService = storeSearchService;
+            _storeService = storeService;
             _settingsManager = settingsManager;
             _allRecords = allRecords;
             AttachValidators();
@@ -127,7 +127,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
                 .WithExceededMaxLengthCodeAndMessage("Preferred Communication", 64)
                 .WithImportState();
 
-            RuleFor(x => x).SetValidator(_ => new ImportAccountValidator(_userManager, _passwordValidator, _memberService, _storeSearchService, _settingsManager, _allRecords));
+            RuleFor(x => x).SetValidator(_ => new ImportAccountValidator(_userManager, _passwordValidator, _memberService, _storeService, _settingsManager, _allRecords));
         }
     }
 }

--- a/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactsValidator.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Data/Validation/ImportContactsValidator.cs
@@ -8,13 +8,13 @@ using VirtoCommerce.StoreModule.Core.Services;
 
 namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
 {
-    public sealed class ImportContactsValidator: AbstractValidator<ImportRecord<ImportableContact>[]>
+    public sealed class ImportContactsValidator : AbstractValidator<ImportRecord<ImportableContact>[]>
     {
         private readonly IImportMemberValidator<ImportableContact> _memberValidator;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly IPasswordValidator<ApplicationUser> _passwordValidator;
         private readonly IMemberService _memberService;
-        private readonly IStoreSearchService _storeSearchService;
+        private readonly IStoreService _storeService;
         private readonly ISettingsManager _settingsManager;
 
         public ImportContactsValidator(
@@ -22,14 +22,14 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
             SignInManager<ApplicationUser> signInManager,
             IPasswordValidator<ApplicationUser> passwordValidator,
             IMemberService memberService,
-            IStoreSearchService storeSearchService,
+            IStoreService storeService,
             ISettingsManager settingsManager)
         {
             _memberValidator = memberValidator;
             _signInManager = signInManager;
             _passwordValidator = passwordValidator;
             _memberService = memberService;
-            _storeSearchService = storeSearchService;
+            _storeService = storeService;
             _settingsManager = settingsManager;
 
             AttachValidators();
@@ -40,7 +40,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Data.Validation
             RuleFor(importRecords => importRecords).SetValidator(_ => new ImportEntitiesAreNotDuplicatesValidator<ImportableContact>());
             RuleFor(importRecords => importRecords).SetValidator(_ => new ImportEntitiesAdditionalLinesValidator<ImportableContact>());
             RuleForEach(importRecords => importRecords).SetValidator(_memberValidator);
-            RuleForEach(importRecords => importRecords).SetValidator(allRecords => new ImportContactValidator(_signInManager.UserManager, _passwordValidator, _memberService, _storeSearchService, _settingsManager, allRecords));
+            RuleForEach(importRecords => importRecords).SetValidator(allRecords => new ImportContactValidator(_signInManager.UserManager, _passwordValidator, _memberService, _storeService, _settingsManager, allRecords));
         }
     }
 }

--- a/tests/VirtoCommerce.CustomerExportImportModule.Tests/CsvMemberValidationTests.cs
+++ b/tests/VirtoCommerce.CustomerExportImportModule.Tests/CsvMemberValidationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,7 +16,6 @@ using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.StoreModule.Core.Model;
-using VirtoCommerce.StoreModule.Core.Model.Search;
 using VirtoCommerce.StoreModule.Core.Services;
 using Xunit;
 
@@ -713,23 +713,19 @@ namespace VirtoCommerce.CustomerExportImportModule.Tests
             return memberServiceMock.Object;
         }
 
-        private static IStoreSearchService GetStoreSearchService()
+        private static IStoreService GetStoreService()
         {
-            var storeSearchServiceMock = new Mock<IStoreSearchService>();
+            var storeSearchServiceMock = new Mock<IStoreService>();
             storeSearchServiceMock
-                .Setup(x => x.SearchAsync(It.IsAny<StoreSearchCriteria>(), It.IsAny<bool>()))
-                .ReturnsAsync((StoreSearchCriteria criteria, bool _) =>
+                .Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync((IList<string> ids, string _, bool _) =>
                 {
                     var stores = new List<Store>
                     {
                         new() { Id = "TestStore", Name = "Test Store" },
                         new() { Id = "TestStore2", Name = "Test Store 2" }
                     };
-                    return new StoreSearchResult
-                    {
-                        Results = stores.Where(store => criteria.ObjectIds.Contains(store.Id)).ToList(),
-                        TotalCount = stores.Count,
-                    };
+                    return stores.Where(store => ids.Contains(store.Id, StringComparer.OrdinalIgnoreCase)).ToList();
                 });
             return storeSearchServiceMock.Object;
         }
@@ -760,7 +756,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Tests
 
         private static ImportMemberValidator<ImportableOrganization> GetOrganizationMemberValidator() => new(GetOrganizationAddressValidator(), GetCountriesService(), GetDynamicPropertyDictionaryItemsSearchService());
 
-        private static ImportContactsValidator GetContactsValidator() => new(GetContactMemberValidator(), GetSignInManager(), GetPasswordValidator(), GetMemberService(), GetStoreSearchService(), GetSettingsManager());
+        private static ImportContactsValidator GetContactsValidator() => new(GetContactMemberValidator(), GetSignInManager(), GetPasswordValidator(), GetMemberService(), GetStoreService(), GetSettingsManager());
 
         private static ImportOrganizationsValidator GetOrganizationsValidator() => new(GetOrganizationMemberValidator());
     }

--- a/tests/VirtoCommerce.CustomerExportImportModule.Tests/CsvMemberValidationTests.cs
+++ b/tests/VirtoCommerce.CustomerExportImportModule.Tests/CsvMemberValidationTests.cs
@@ -499,7 +499,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Tests
                             }
                         }
                     },
-                    ModuleConstants.ValidationErrors.InvalidValue, "Test1"
+                    ModuleConstants.ValidationErrors.PasswordDoesntMeetSecurityPolicy, "Test1"
                 };
             }
         }
@@ -627,7 +627,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Tests
             var validationResult = await validator.ValidateAsync(importRecords);
 
             // Assert
-            var error = validationResult.Errors.First(validationError => validationError.ErrorCode == errorCode);
+            var error = validationResult.Errors.Find(validationError => validationError.ErrorCode == errorCode);
             Assert.NotNull(error);
             Assert.Equal(failedEntityFullName, (error.CustomState as ImportValidationState<ImportableContact>)?.InvalidRecord.Record.ContactFullName);
         }


### PR DESCRIPTION
## Description
Add a new validation that is case-sensitive for the StoreId.

If StoreId in the imported user is not case-sensitive equal we have empty control in Admin UI.

![image](https://github.com/VirtoCommerce/vc-module-customer-export-import/assets/83034617/5600d241-ffa0-44ea-9573-e9bb0d3cc489)

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CustomerExportImport_3.806.0-pr-94-9901.zip