### PR TITLE
VCST-3135: Contact Associated Organization Ids Not Imported 

### DIFF
--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/CsvContact.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/CsvContact.cs
@@ -44,6 +44,14 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
         public override string Phones { get; set; }
 
         [Optional]
+        [Name("Contact Associated Organization Ids")]
+        public virtual string AssociatedOrganizationIds { get; set; }
+
+        [Optional]
+        [Name("Contact User Groups")]
+        public virtual string UserGroups { get; set; }
+
+        [Optional]
         [Name("Contact Emails")]
         public override string Emails { get; set; }
 
@@ -74,6 +82,10 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
         [Optional]
         [Name("Contact Preferred delivery")]
         public virtual string PreferredDelivery { get; set; }
+
+        [Optional]
+        [Name("Account Id")]
+        public virtual string AccountId { get; set; }
 
         [Optional]
         [Name("Organization Id")]

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ExportableContact.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ExportableContact.cs
@@ -67,12 +67,12 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
         [Index(18)]
         [Optional]
         [Name("Contact Associated Organization Ids")]
-        public string AssociatedOrganizationIds { get; set; }
+        public override string AssociatedOrganizationIds { get; set; }
 
         [Index(19)]
         [Optional]
-        [Name("Contact User groups")]
-        public string UserGroups { get; set; }
+        [Name("Contact User Groups")]
+        public override string UserGroups { get; set; }
 
         [Index(20)]
         public override string AddressType { get; set; }
@@ -116,7 +116,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
         [Index(33)]
         [Optional]
         [Name("Account Id")]
-        public string AccountId { get; set; }
+        public override string AccountId { get; set; }
 
         [Index(34)]
         public override string AccountLogin { get; set; }

--- a/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportableContact.cs
+++ b/src/VirtoCommerce.CustomerExportImportModule.Core/Models/ImportableContact.cs
@@ -50,6 +50,8 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
                 const StringSplitOptions splitOptions = StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries;
                 target.Emails = string.IsNullOrEmpty(Emails) ? null : Emails.Split(',', splitOptions);
                 target.Phones = string.IsNullOrEmpty(Phones) ? null : Phones.Split(',', splitOptions);
+                target.AssociatedOrganizations = string.IsNullOrEmpty(AssociatedOrganizationIds) ? null : AssociatedOrganizationIds.Split(',', splitOptions);
+                target.Groups = string.IsNullOrEmpty(UserGroups) ? null : UserGroups.Split(',', splitOptions);
 
                 PatchDynamicProperties(target);
 
@@ -58,6 +60,7 @@ namespace VirtoCommerce.CustomerExportImportModule.Core.Models
                     && !target.SecurityAccounts.Any(x => x.UserName.EqualsInvariant(AccountLogin) && x.Email.EqualsInvariant(AccountEmail)))
                 {
                     var user = AbstractTypeFactory<ApplicationUser>.TryCreateInstance();
+                    user.Id = AccountId;
                     user.StoreId = StoreId;
                     user.UserName = AccountLogin;
                     user.Email = AccountEmail;


### PR DESCRIPTION
## Description
fix: Add new properties to CsvContact and update imports. Added optional properties: AssociatedOrganizationIds, UserGroups, and AccountId to CsvContact.cs.

## References
### QA-test:
### Jira-link:
### Artifact URL:
